### PR TITLE
Feature: Config option in VSCode Extension Settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/server/src/clj_kondo/lsp_server/impl/server.clj
+++ b/server/src/clj_kondo/lsp_server/impl/server.clj
@@ -28,6 +28,7 @@
            [java.util.concurrent CompletableFuture])
   (:require [clojure.string :as str]
             [clj-kondo.core :as clj-kondo]
+            [clojure.edn :as edn]
             [clojure.java.io :as io]))
 
 (set! *warn-on-reflection* true)
@@ -116,11 +117,16 @@
     (config-dir dir)))
 
 (defn config-options
-  [args path]
-  (str/join "/" (concat [path] [(first args)])))
+  [arg ^java.io.File config-dir]
+  (let [file (io/file arg)]
+       (if (.isFile file)
+         (if (.isRelative file)
+           (io/file config-dir arg)
+           (file))
+         (edn/read-string arg))))
 
 (defn lint! [text uri]
-  
+  ()
   (let [lang (uri->lang uri)
         ^java.io.File cfg-dir (uri->config-dir uri)
         {:keys [:findings]} (with-in-str text
@@ -128,7 +134,7 @@
                                                   {:lint ["-"]
                                                    :lang lang}
                                                 cfg-dir (assoc :config-dir cfg-dir)
-                                                cfg-dir (assoc :config (config-options @arg-options (.getPath cfg-dir))))))
+                                                cfg-dir (assoc :config (config-options @arg-options cfg-dir)))))
         lines (str/split text #"\r?\n")]
     (.publishDiagnostics ^LanguageClient @proxy-state
                          (PublishDiagnosticsParams.

--- a/server/src/clj_kondo/lsp_server/main.clj
+++ b/server/src/clj_kondo/lsp_server/main.clj
@@ -8,8 +8,8 @@
 
 ;;;; parse command line options
 
-(defn -main [& options]
-  (server/run-server! options))
+(defn -main [& args]
+  (server/run-server! args))
 
 ;;;; Scratch
 

--- a/server/src/clj_kondo/lsp_server/main.clj
+++ b/server/src/clj_kondo/lsp_server/main.clj
@@ -9,7 +9,7 @@
 ;;;; parse command line options
 
 (defn -main [& options]
-  (server/run-server!))
+  (server/run-server! options))
 
 ;;;; Scratch
 

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clj-kondo",
-  "version": "2020.1.13",
+  "version": "2020.7.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -38,10 +38,10 @@
     "configuration": {
       "title": "clj-kondo",
       "properties": {
-        "clj-kondo.config.filePath": {
+        "clj-kondo.config.configArgs": {
           "type": "string",
           "scope": "application",
-          "markdownDescription": "Specifies file argument or EDN arguement to merge with config.edn."
+          "markdownDescription": "Specifies config options to pass to clj-kondo on lint. If specifying a path for an additional edn file, do not include .clj-kondo, that will be included automatically."
         }
       }
     }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -33,5 +33,17 @@
     "tslint": "^5.16.0",
     "typescript": "^3.6.4",
     "vscode": "^1.1.35"
+  },
+  "contributes": {
+    "configuration": {
+      "title": "clj-kondo",
+      "properties": {
+        "clj-kondo.config.filePath": {
+          "type": "string",
+          "scope": "application",
+          "markdownDescription": "Specifies file argument or EDN arguement to merge with config.edn."
+        }
+      }
+    }
   }
 }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -38,7 +38,7 @@
     "configuration": {
       "title": "clj-kondo",
       "properties": {
-        "clj-kondo.config.configArgs": {
+        "clj-kondo.config": {
           "type": "string",
           "scope": "application",
           "markdownDescription": "Specifies config options to pass to clj-kondo on lint. If specifying a path for an additional edn file, do not include .clj-kondo, that will be included automatically."

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -41,7 +41,7 @@ export function activate(context: ExtensionContext) {
     // The debug options for the server
     // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
     let debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] };
-    let args: string = workspace.getConfiguration().get('clj-kondo.config.configArgs');
+    let args: string = workspace.getConfiguration().get('clj-kondo.config');
     let jarPath = path.join(context.extensionPath, 'clj-kondo.lsp-standalone.jar');
     let serverOptions: ServerOptions = {
         run: {command: 'java', args:['-jar', jarPath, args]},

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -41,11 +41,11 @@ export function activate(context: ExtensionContext) {
     // The debug options for the server
     // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
     let debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] };
-    let configPath: string = workspace.getConfiguration().get('clj-kondo.config.filePath');
+    let args: string = workspace.getConfiguration().get('clj-kondo.config.configArgs');
     let jarPath = path.join(context.extensionPath, 'clj-kondo.lsp-standalone.jar');
     let serverOptions: ServerOptions = {
-        run: {command: 'java', args:['-jar', jarPath, configPath] },
-        debug: {command: 'java', args:['-jar', jarPath, configPath]},
+        run: {command: 'java', args:['-jar', jarPath, args]},
+        debug: {command: 'java', args:['-jar', jarPath, args]},
     }
 
     // If the extension is launched in debug mode then the debug server options are used

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -41,10 +41,11 @@ export function activate(context: ExtensionContext) {
     // The debug options for the server
     // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
     let debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] };
+    let configPath: string = workspace.getConfiguration().get('clj-kondo.config.filePath');
     let jarPath = path.join(context.extensionPath, 'clj-kondo.lsp-standalone.jar');
     let serverOptions: ServerOptions = {
-        run: {command: 'java', args:['-jar', jarPath] },
-        debug: {command: 'java', args:['-jar', jarPath]},
+        run: {command: 'java', args:['-jar', jarPath, configPath] },
+        debug: {command: 'java', args:['-jar', jarPath, configPath]},
     }
 
     // If the extension is launched in debug mode then the debug server options are used


### PR DESCRIPTION
Added a setting to pass a file path under .clj-kondo to --config when linting.